### PR TITLE
Investigate recurring issue

### DIFF
--- a/frontend/app/middleware/guest.ts
+++ b/frontend/app/middleware/guest.ts
@@ -1,12 +1,8 @@
 export default defineNuxtRouteMiddleware((to, from) => {
-
-
   const key = process.server ? 'token' : 'XSRF-TOKEN'
-
   const token = useCookie(key)
 
-
-  if (token.value)
-    return navigateTo('/signin')
-
+  if (token.value) {
+    return navigateTo('/')
+  }
 })

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -4,6 +4,17 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   modules: ['@nuxt/ui'],
   css: ['~/assets/css/main.css'],
+  future: {
+    compatibilityVersion: 4
+  },
+  nitro: {
+    devProxy: {
+      '/_nuxt/': {
+        target: 'http://localhost:3000',
+        changeOrigin: true
+      }
+    }
+  },
   runtimeConfig: {
     API_URL: "http://localhost:8000",
     public: {


### PR DESCRIPTION
Fixes infinite redirect loop on `/signin` by redirecting authenticated users to the home page.

The `guest` middleware was incorrectly redirecting users with an existing token back to `/signin`, leading to an infinite loop and a 500 error when trying to access the sign-in page. This change ensures authenticated users are redirected to `/` instead. Minor `nuxt.config.ts` adjustments are included for dev stability.

---
<a href="https://cursor.com/background-agent?bcId=bc-97926055-6925-4a0e-9f2e-654e286726b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97926055-6925-4a0e-9f2e-654e286726b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

